### PR TITLE
:arrow_up: 同步修订Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "chrono",
  "entity",
  "futures",
+ "lazy_static",
  "migration",
  "oblivion",
  "rand",


### PR DESCRIPTION
建议Quantumix的contributor应当使用最新的rust版本，不建议使用nightly。