### PR TITLE
fix(deps): bump @vue-router to v4.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "primeicons": "^7.0.0",
     "primevue": "4.0.0-beta.2",
     "unocss": "^0.60.2",
-    "vue": "^3.4.27"
+    "vue": "^3.4.27",
+    "vue-router": "^4.3.2"
   },
   "devDependencies": {
     "@tauri-apps/cli": "2.0.0-beta.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       vue:
         specifier: ^3.4.27
         version: 3.4.27(typescript@5.4.5)
+      vue-router:
+        specifier: ^4.3.2
+        version: 4.3.2(vue@3.4.27(typescript@5.4.5))
     devDependencies:
       '@tauri-apps/cli':
         specifier: 2.0.0-beta.17
@@ -1271,6 +1274,11 @@ packages:
       '@vue/composition-api':
         optional: true
 
+  vue-router@4.3.2:
+    resolution: {integrity: sha512-hKQJ1vDAZ5LVkKEnHhmm1f9pMiWIBNGF5AwU67PdH7TyXCj/a4hTccuUuYCAMgJK6rO/NVYtQIEN3yL8CECa7Q==}
+    peerDependencies:
+      vue: ^3.2.0
+
   vue-template-compiler@2.7.16:
     resolution: {integrity: sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==}
 
@@ -2506,6 +2514,11 @@ snapshots:
 
   vue-demi@0.14.7(vue@3.4.27(typescript@5.4.5)):
     dependencies:
+      vue: 3.4.27(typescript@5.4.5)
+
+  vue-router@4.3.2(vue@3.4.27(typescript@5.4.5)):
+    dependencies:
+      '@vue/devtools-api': 6.6.1
       vue: 3.4.27(typescript@5.4.5)
 
   vue-template-compiler@2.7.16:


### PR DESCRIPTION
# Why this PR?

Resolved: #36

## What's being changed?

Add `@vue-router` as dependency.
