### PR TITLE
docs: mark descriptions as documentation in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
-# Why this PR?
+# <!-- Why this PR? -->
 
-Resolved: #ISSUE_ID
+Resolved: <!-- #ISSUE_ID -->
 
 ## What's being changed?
+
+<!--
 
 (if available, include any code snippets, screenshots, or gif files)
 
@@ -13,3 +15,5 @@ Check off the following:
    - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the data directory.
 
 2. For content changes, I have completed the self-review checklist.
+
+-->


### PR DESCRIPTION
# Update `PULL_REQUEST_TEMPLATE.md`

Resolved: 

## What's being changed?

`PULL_REQUEST_TEMPLATE.md` descriptions were marked as documentation